### PR TITLE
Made GitlabStorageProvider work with Laravel-9 and 10.

### DIFF
--- a/src/GitlabStorageServiceProvider.php
+++ b/src/GitlabStorageServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace RoyVoetman\LaravelGitlabStorage;
 
+use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\ServiceProvider;
 use League\Flysystem\Filesystem;
@@ -10,21 +11,24 @@ use RoyVoetman\FlysystemGitlab\GitlabAdapter;
 
 class GitlabStorageServiceProvider extends ServiceProvider
 {
-    
+
     /**
      * Perform post-registration booting of services.
      */
     public function boot()
     {
-        Storage::extend('gitlab', function ($app, $config) {            
+        Storage::extend('gitlab', function ($app, $config) {
             $client = new Client(
                 $config[ 'project-id' ],
                 $config[ 'branch' ],
                 $config[ 'base-url' ],
                 $config[ 'personal-access-token' ]
             );
-        
-            return new \Illuminate\Filesystem\FilesystemAdapter(new Filesystem(new GitlabAdapter($client)));
+
+            $adapter = new GitlabAdapter($client);
+            $operator = new Filesystem($adapter);
+
+            return new FilesystemAdapter($operator, $adapter);
         });
     }
 


### PR DESCRIPTION
The current implementation doesn't work with Laravel-9 and 10, even though ``composer.json`` has updated dependencies. The call to the ``FilesystemAdapter`` provides only one argument, but it should be using two.

This pull request fixes the issue.

The problem occurs with:
laravel-gitlab-storage: v3.0.0
PHP: 8.1.5
Laravel: v9.52.9 | v10.13.5

Error message is:
```shell
ArgumentCountError

Too few arguments to function Illuminate\Filesystem\FilesystemAdapter::__construct(), 1 passed in [...]/vendor/royvoetman/laravel-gitlab-storage/src/GitlabStorageServiceProvider.php on line 27 and at least 2 expected
```
